### PR TITLE
using geonames.lite.csv by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN apk add --no-cache git nodejs yarn python3 npm ca-certificates wget gnupg ma
   npm install npm@latest -g && \
   npm install -g webpack
 
-RUN wget https://s3.eu-central-1.wasabisys.com/plausible-application/geonames.csv -q
-
 COPY mix.exs ./
 COPY mix.lock ./
 RUN mix local.hex --force && \
@@ -42,8 +40,7 @@ RUN npm run deploy --prefix ./assets && \
   mix phx.digest priv/static && \
   mix download_country_database && \
   # https://hexdocs.pm/sentry/Sentry.Sources.html#module-source-code-storage
-  mix sentry_recompile && \
-  mv geonames.csv ./priv/geonames.csv
+  mix sentry_recompile
 
 WORKDIR /app
 COPY rel rel
@@ -70,7 +67,6 @@ COPY --from=buildcontainer /app/_build/prod/rel/plausible /app
 RUN chown -R plausibleuser:plausibleuser /app
 USER plausibleuser
 WORKDIR /app
-ENV GEONAMES_SOURCE_FILE=/app/lib/plausible-0.0.1/priv/geonames.csv
 ENV LISTEN_IP=0.0.0.0
 ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 8000


### PR DESCRIPTION
This PR makes [`allCountries.txt` (aka `geonames.csv`)](https://github.com/plausible/location#cities) to not be used by default.

Container image with this change: [`ghcr.io/ruslandoga/analytics:pr-1`](https://github.com/ruslandoga/analytics/pkgs/container/analytics/40688610?tag=pr-1)

---

If a more accurate city-level tracking is desired, it should be enabled by mounting a volume with downloaded [`s3://geonames.csv`](https://s3.eu-central-1.wasabisys.com/plausible-application/geonames.csv) and setting `GEONAMES_SOURCE_FILE` to point to it:

```diff
+ curl -O https://s3.eu-central-1.wasabisys.com/plausible-application/geonames.csv
```

```diff
# based on https://github.com/plausible/hosting/blob/f7682057104671b42e3fff3a106f93a32ea14775/docker-compose.yml#L27-L38
  plausible:
    image: ghcr.io/ruslandoga/analytics:pr-1 # works for both arm and x86 archs
    restart: always
    command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run"
    depends_on:
      - plausible_db
      - plausible_events_db
      - mail
    ports:
      - 8000:8000
    env_file:
      - plausible-conf.env
+   # mounts the downloaded geonames.csv
+   # note that using geonames.csv would require additional ~700MB RAM
+   volumes:
+     - ./geonames.csv:/etc/app/geonames.csv:ro
```

```diff
# based on https://github.com/plausible/hosting/blob/f7682057104671b42e3fff3a106f93a32ea14775/plausible-conf.env
ADMIN_USER_EMAIL=replace-me
ADMIN_USER_NAME=replace-me
ADMIN_USER_PWD=replace-me
BASE_URL=replace-me
SECRET_KEY_BASE=replace-me
+ # adds GEONAMES_SOURCE_FILE env var pointing to the mounted `geonames.csv`
+ # note that using geonames.csv would require additional ~700MB RAM
+ GEONAMES_SOURCE_FILE=/etc/app/geonames.csv 
```