### PR TITLE
allow admins to change email and password when DISABLE_AUTH=true

### DIFF
--- a/lib/plausible_web/plugs/auto_auth_plug.ex
+++ b/lib/plausible_web/plugs/auto_auth_plug.ex
@@ -1,6 +1,6 @@
 defmodule PlausibleWeb.AutoAuthPlug do
   import Plug.Conn
-  alias PlausibleWeb.AuthController
+  alias PlausibleWeb.{AuthController, AuthView}
 
   def init(options) do
     options
@@ -10,6 +10,7 @@ defmodule PlausibleWeb.AutoAuthPlug do
     cond do
       Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_authentication) ->
         conn
+        |> Phoenix.Controller.put_view(AuthView)
         |> AuthController.login(%{
           "email" => Application.fetch_env!(:plausible, :admin_email),
           "password" => Application.fetch_env!(:plausible, :admin_pwd)

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -17,36 +17,8 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
           password: Application.get_env(:plausible, :admin_pwd)
         )
 
-      # goto landing page
-      conn = get(conn, "/")
-      assert get_session(conn, :current_user_id) == admin_user.id
-      assert redirected_to(conn) == "/sites"
-
-      # trying logging out
-      conn = get(conn, "/logout")
-      assert redirected_to(conn) == "/"
-      conn = get(conn, "/")
-      assert redirected_to(conn) == "/sites"
-    end
-
-    # https://github.com/plausible/analytics/issues/1271
-    test "allows editing admin user email when authentication is disabled", ctx do
-      %{conn: conn} = ctx
-      set_config(disable_authentication: true)
-
-      og_admin_user =
-        insert(:user,
-          email: Application.get_env(:plausible, :admin_email),
-          password: Application.get_env(:plausible, :admin_pwd)
-        )
-
-      # change admin user's email address
-      {:ok, admin_user} =
-        og_admin_user
-        |> Ecto.Changeset.change(%{email: "new-admin@email.com"})
-        |> Plausible.Repo.update()
-
-      refute og_admin_user.email == admin_user.email
+      # rate limit workaround
+      conn = put_req_header(conn, "x-forwarded-for", "23.23.23.23")
 
       # goto landing page
       conn = get(conn, "/")
@@ -54,8 +26,10 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
       assert redirected_to(conn) == "/sites"
 
       # trying logging out
+      conn = recycle(conn, ~w(x-forwarded-for))
       conn = get(conn, "/logout")
       assert redirected_to(conn) == "/"
+      conn = recycle(conn, ~w(x-forwarded-for))
       conn = get(conn, "/")
       assert redirected_to(conn) == "/sites"
     end
@@ -65,6 +39,64 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
       conn = get(conn, "/register")
       assert redirected_to(conn) == "/login"
     end
+  end
+
+  # https://github.com/plausible/analytics/issues/1271
+  test "admin user email and password are synced to app env", %{conn: conn} do
+    set_config(disable_authentication: true)
+
+    admin_user =
+      insert(:user,
+        email: Application.get_env(:plausible, :admin_email),
+        password: Application.get_env(:plausible, :admin_pwd)
+      )
+
+    assert admin_user.email == "admin@email.com"
+    assert admin_user.password == "fakepassword"
+
+    # rate limit workaround
+    conn = put_req_header(conn, "x-forwarded-for", "24.24.24.24")
+
+    # auto login
+    conn = get(conn, "/")
+
+    # change admin user's email address
+    new_email = "new-admin@email.com"
+    user_params = %{"user" => %{"email" => new_email}}
+    conn = recycle(conn, ~w(x-forwarded-for))
+    conn = put(conn, "/settings", user_params)
+    assert redirected_to(conn) == "/settings"
+
+    # verify the changed email
+    admin_user = Plausible.Repo.reload!(admin_user)
+    assert admin_user.email == new_email
+    assert Application.get_env(:plausible, :admin_email) == new_email
+
+    # change admin user's password
+    new_password = "sw0rdfish"
+    password_params = %{"password" => new_password}
+    conn = recycle(conn, ~w(x-forwarded-for))
+    conn = post(conn, "/password", password_params)
+    assert redirected_to(conn) == "/sites/new"
+
+    # verify the changed password
+    admin_user = Plausible.Repo.reload!(admin_user)
+    assert Plausible.Auth.Password.match?(new_password, admin_user.password_hash)
+    assert Application.get_env(:plausible, :admin_pwd) == new_password
+
+    # goto landing page
+    conn = recycle(conn, ~w(x-forwarded-for))
+    conn = get(conn, "/")
+    assert get_session(conn, :current_user_id) == admin_user.id
+    assert redirected_to(conn) == "/sites"
+
+    # trying logging out
+    conn = recycle(conn, ~w(x-forwarded-for))
+    conn = get(conn, "/logout")
+    assert redirected_to(conn) == "/"
+    conn = recycle(conn, ~w(x-forwarded-for))
+    conn = get(conn, "/")
+    assert redirected_to(conn) == "/sites"
   end
 
   def set_config(config) do

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -29,6 +29,37 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
       assert redirected_to(conn) == "/sites"
     end
 
+    # https://github.com/plausible/analytics/issues/1271
+    test "allows editing admin user email when authentication is disabled", ctx do
+      %{conn: conn} = ctx
+      set_config(disable_authentication: true)
+
+      og_admin_user =
+        insert(:user,
+          email: Application.get_env(:plausible, :admin_email),
+          password: Application.get_env(:plausible, :admin_pwd)
+        )
+
+      # change admin user email
+      {:ok, admin_user} =
+        og_admin_user
+        |> Ecto.Changeset.change(%{email: "new-admin@email.com"})
+        |> Plausible.Repo.update()
+
+      refute og_admin_user.email == admin_user.email
+
+      # goto landing page
+      conn = get(conn, "/")
+      assert get_session(conn, :current_user_id) == admin_user.id
+      assert redirected_to(conn) == "/sites"
+
+      # trying logging out
+      conn = get(conn, "/logout")
+      assert redirected_to(conn) == "/"
+      conn = get(conn, "/")
+      assert redirected_to(conn) == "/sites"
+    end
+
     test "disable registration", %{conn: conn} do
       set_config(disable_registration: true)
       conn = get(conn, "/register")
@@ -37,6 +68,9 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
   end
 
   def set_config(config) do
+    prev_env = Application.get_env(:plausible, :selfhost)
+    on_exit(fn -> Application.put_env(:plausible, :selfhost, prev_env) end)
+
     updated_config =
       Keyword.merge(
         [disable_authentication: false, disable_registration: false],

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -40,7 +40,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
           password: Application.get_env(:plausible, :admin_pwd)
         )
 
-      # change admin user email
+      # change admin user's email address
       {:ok, admin_user} =
         og_admin_user
         |> Ecto.Changeset.change(%{email: "new-admin@email.com"})

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -35,6 +35,26 @@ defmodule PlausibleWeb.ConnCase do
       Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, {:shared, self()})
     end
 
+    prev_admin_email = Application.fetch_env!(:plausible, :admin_email)
+    prev_admin_password = Application.fetch_env!(:plausible, :admin_pwd)
+
+    on_exit(fn ->
+      email_changed? = prev_admin_email != Application.fetch_env!(:plausible, :admin_email)
+      pwd_changed? = prev_admin_password != Application.fetch_env!(:plausible, :admin_pwd)
+
+      if tags[:async] && (email_changed? || pwd_changed?) do
+        raise "this test edits admin credentials stored in app env, please make sure to run it in sync mode"
+      end
+
+      if email_changed? do
+        :ok = Application.put_env(:plausible, :admin_email, prev_admin_email)
+      end
+
+      if pwd_changed? do
+        :ok = Application.put_env(:plausible, :admin_pwd, prev_admin_password)
+      end
+    end)
+
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 end


### PR DESCRIPTION
### Changes

Fixes https://github.com/plausible/analytics/issues/1271

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
