### PR TITLE
make CLICKHOUSE_MAX_BUFFER_SIZE mean bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Show Outbound Links / File Downloads / 404 Pages / Cloaked Links instead of Goal Conversions when filtering by the corresponding goal
 - Require custom properties to be explicitly added from Site Settings > Custom Properties in order for them to show up on the dashboard
 - GA/SC sections moved to new settings: Integrations
+- `CLICKHOUSE_MAX_BUFFER_SIZE` now represents bytes and defaults to `100000` (100KB)
 
 ### Fixed
 - Only return `(none)` values in custom property breakdown for the first page (pagination) of results

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -134,7 +134,7 @@ ch_db_url =
 
 {ch_max_buffer_size, ""} =
   config_dir
-  |> get_var_from_path_or_env("CLICKHOUSE_MAX_BUFFER_SIZE", "10000")
+  |> get_var_from_path_or_env("CLICKHOUSE_MAX_BUFFER_SIZE", "100000")
   |> Integer.parse()
 
 ### Mandatory params End


### PR DESCRIPTION
### Changes

This PR makes `CLICKHOUSE_MAX_BUFFER_SIZE` represent bytes.
`GOOGLE_BUFFER_SIZE` stays the same and still represents records count.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI